### PR TITLE
fix: 공룡게임 모달이 비활성 상태시에도, 스페이스바 이벤트 발생(다른 컴포넌트와 충돌)

### DIFF
--- a/src/scripts/dino.js
+++ b/src/scripts/dino.js
@@ -1,8 +1,8 @@
-const canvas = document.getElementById('canvas');
-const ctx = canvas.getContext('2d');
-const startBtn = document.getElementById('start-btn');
-const restartBtn = document.getElementById('restart-btn');
-const pauseBtn = document.getElementById('pause-btn');
+const canvas = document.getElementById("canvas");
+const ctx = canvas.getContext("2d");
+const startBtn = document.getElementById("start-btn");
+const restartBtn = document.getElementById("restart-btn");
+const pauseBtn = document.getElementById("pause-btn");
 
 // 캔버스 크기 설정
 canvas.width = 800;
@@ -10,19 +10,19 @@ canvas.height = 300;
 
 // 이미지 불러오기
 const cactusImage = new Image();
-cactusImage.src = '/img/dinosour/cactus.png';
+cactusImage.src = "/img/dinosour/cactus.png";
 
 const dinosourRunImage = new Image();
-dinosourRunImage.src = '/img/dinosour/dinosour-run1.png';
+dinosourRunImage.src = "/img/dinosour/dinosour-run1.png";
 
 const dinosourRun2Image = new Image();
-dinosourRun2Image.src = '/img/dinosour/dinosour-run2.png';
+dinosourRun2Image.src = "/img/dinosour/dinosour-run2.png";
 
 const dinosourFailImage = new Image();
-dinosourFailImage.src = '/img/dinosour/dinosour-fail.png';
+dinosourFailImage.src = "/img/dinosour/dinosour-fail.png";
 
 const dinosourJumpImage = new Image();
-dinosourJumpImage.src = '/img/dinosour/dinosour-jump.png';
+dinosourJumpImage.src = "/img/dinosour/dinosour-jump.png";
 
 // 게임 상태 변수
 let gameStarted = false;
@@ -34,7 +34,7 @@ let gamePaused = false;
 // 다크모드 전환에 따라 글자색이 바뀌도록 설정 - 함수로 변경
 function getCurrentThirdColor() {
   return getComputedStyle(document.documentElement)
-    .getPropertyValue('--third-color')
+    .getPropertyValue("--third-color")
     .trim();
 }
 
@@ -44,18 +44,19 @@ const dino = {
   y: 200,
   width: 50,
   height: 50,
-  state: 'run',
+  state: "run",
   draw() {
     let image;
-    if (this.state === 'jump') {
+    if (this.state === "jump") {
       image = dinosourJumpImage;
-    } else if (this.state === 'fail') {
+    } else if (this.state === "fail") {
       image = dinosourFailImage;
     } else {
-      image = (Math.floor(timer / 10) % 2 === 0) ? dinosourRunImage : dinosourRun2Image;
+      image =
+        Math.floor(timer / 10) % 2 === 0 ? dinosourRunImage : dinosourRun2Image;
     }
     ctx.drawImage(image, this.x, this.y);
-  }
+  },
 };
 
 // 장애물 설정
@@ -84,33 +85,41 @@ let gameOver = false;
 function drawScore() {
   const score = Math.floor(timer / 10);
   ctx.fillStyle = getCurrentThirdColor();
-  ctx.font = '20px Arial';
-  ctx.textAlign = 'right';
+  ctx.font = "20px Arial";
+  ctx.textAlign = "right";
   ctx.fillText(`Score: ${score}`, canvas.width - 20, 30);
 }
 
 // 게임오버 메시지 표시 함수 수정 - 실시간으로 색상 가져오기
 function drawGameOver() {
   ctx.fillStyle = getCurrentThirdColor();
-  ctx.font = 'bold 36px Arial';
-  ctx.textAlign = 'center';
-  ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2 - 20);
-  
-  ctx.fillStyle = '#666666';
-  ctx.font = '18px Arial';
-  ctx.fillText('Press SPACE to restart', canvas.width / 2, canvas.height / 2 + 20);
+  ctx.font = "bold 36px Arial";
+  ctx.textAlign = "center";
+  ctx.fillText("GAME OVER", canvas.width / 2, canvas.height / 2 - 20);
+
+  ctx.fillStyle = "#666666";
+  ctx.font = "18px Arial";
+  ctx.fillText(
+    "Press SPACE to restart",
+    canvas.width / 2,
+    canvas.height / 2 + 20
+  );
 }
 
 // 일시정지 메시지 표시 함수 수정 - 실시간으로 색상 가져오기
 function drawPaused() {
   ctx.fillStyle = getCurrentThirdColor();
-  ctx.font = 'bold 36px Arial';
-  ctx.textAlign = 'center';
-  ctx.fillText('PAUSE', canvas.width / 2, canvas.height / 2 - 20);
-  
-  ctx.fillStyle = '#666666';
-  ctx.font = '18px Arial';
-  ctx.fillText('Click PAUSE button to resume', canvas.width / 2, canvas.height / 2 + 20);
+  ctx.font = "bold 36px Arial";
+  ctx.textAlign = "center";
+  ctx.fillText("PAUSE", canvas.width / 2, canvas.height / 2 - 20);
+
+  ctx.fillStyle = "#666666";
+  ctx.font = "18px Arial";
+  ctx.fillText(
+    "Click PAUSE button to resume",
+    canvas.width / 2,
+    canvas.height / 2 + 20
+  );
 }
 
 // 게임 초기화 함수
@@ -122,7 +131,7 @@ function resetGame() {
   gameOver = false;
   gamePaused = false;
   dino.y = 200;
-  dino.state = 'run';
+  dino.state = "run";
   nextCactusTimer = 0;
   cactusInterval = 200;
   gameSpeed = 1;
@@ -132,11 +141,11 @@ function resetGame() {
 function togglePause() {
   if (gameStarted && !gameOver) {
     gamePaused = !gamePaused;
-    
+
     if (gamePaused) {
-      pauseBtn.textContent = '이어서하기';
+      pauseBtn.textContent = "이어서하기";
     } else {
-      pauseBtn.textContent = '일시정지';
+      pauseBtn.textContent = "일시정지";
     }
   }
 }
@@ -147,7 +156,7 @@ function startGame() {
   startBtn.disabled = true;
   restartBtn.disabled = false;
   pauseBtn.disabled = false;
-  pauseBtn.textContent = 'Pause';
+  pauseBtn.textContent = "Pause";
   resetGame();
   frame();
 }
@@ -160,7 +169,7 @@ function restartGame() {
   startBtn.disabled = true;
   restartBtn.disabled = false;
   pauseBtn.disabled = false;
-  pauseBtn.textContent = 'Pause';
+  pauseBtn.textContent = "Pause";
   frame();
 }
 
@@ -196,13 +205,13 @@ function frame() {
     if (jumpSwitch === true) {
       dino.y -= 5;
       jumpTimer++;
-      dino.state = 'jump';
+      dino.state = "jump";
     } else {
       if (dino.y < 200) {
         dino.y += 5;
-        dino.state = 'jump';
+        dino.state = "jump";
       } else {
-        dino.state = 'run';
+        dino.state = "run";
       }
     }
 
@@ -213,17 +222,17 @@ function frame() {
   }
 
   dino.draw();
-  
+
   // 스코어 표시 추가
   if (gameStarted) {
     drawScore();
   }
-  
+
   // 게임오버 메시지 표시 추가
   if (gameOver) {
     drawGameOver();
   }
-  
+
   // 일시정지 메시지 표시 추가
   if (gamePaused) {
     drawPaused();
@@ -235,16 +244,20 @@ function crash(dino, cactus) {
   const xSub = cactus.x - (dino.x + dino.width);
   const ySub = cactus.y - (dino.y + dino.height);
   if (xSub < 0 && ySub < 0 && !gameOver) {
-    dino.state = 'fail';
+    dino.state = "fail";
     gameOver = true;
     pauseBtn.disabled = true;
     setTimeout(() => cancelAnimationFrame(animation), 100);
   }
 }
 
-// 키보드 이벤트 (스페이스바)
-document.addEventListener('keydown', function (e) {
-  if (e.code === 'Space') {
+// 키보드 이벤트 (스페이스바) <- 모달창 작동 안할때도 적용되는 부분 수정
+document.addEventListener("keydown", function (e) {
+  if (["INPUT", "TEXTAREA"].includes(e.target.tagName)) return;
+
+  if (!gameModal || !gameModal.open) return;
+
+  if (e.code === "Space") {
     e.preventDefault();
 
     if (!gameStarted) {
@@ -258,9 +271,9 @@ document.addEventListener('keydown', function (e) {
 });
 
 // 버튼 이벤트
-startBtn.addEventListener('click', startGame);
-restartBtn.addEventListener('click', restartGame);
-pauseBtn.addEventListener('click', togglePause);
+startBtn.addEventListener("click", startGame);
+restartBtn.addEventListener("click", restartGame);
+pauseBtn.addEventListener("click", togglePause);
 
 // 초기 화면
 function drawInitialScreen() {
@@ -272,7 +285,6 @@ function drawInitialScreen() {
 }
 drawInitialScreen();
 
-
 // -----------------------------------------------------------------------------------
 // 모달창 제어 기능
 const modalStartBtn = document.querySelector(".modal-start__btn");
@@ -280,24 +292,17 @@ const modalEndBtn = document.querySelector(".modal-end__btn");
 const gameModal = document.querySelector(".dino-game__modal__canvas");
 
 // 페이지 로드 시 모달창 숨기기
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener("DOMContentLoaded", function () {
   if (gameModal) {
-    gameModal.style.display = 'none';
+    gameModal.style.display = "none";
   }
 });
-
-// 만약 DOM이 이미 로드되었다면 즉시 실행
-if (document.readyState !== 'loading') {
-  if (gameModal) {
-    gameModal.style.display = 'none';
-  }
-}
 
 // 게임하기 버튼 클릭 시 모달창 열기
 if (modalStartBtn) {
   modalStartBtn.addEventListener("click", () => {
     if (gameModal) {
-      gameModal.style.display = 'block';
+      gameModal.style.display = "block";
       gameModal.showModal();
     }
   });
@@ -308,24 +313,27 @@ if (modalEndBtn) {
   modalEndBtn.addEventListener("click", () => {
     if (gameModal) {
       gameModal.close();
-      gameModal.style.display = 'none';
+      gameModal.style.display = "none";
+    }
+    if (!gamePaused && gameStarted && !gameOver) {
+      togglePause();
     }
   });
 }
 
 // 다크모드 감지
-const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+const darkModeMediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
-darkModeMediaQuery.addEventListener('change', () => {
+darkModeMediaQuery.addEventListener("change", () => {
   if (gameOver) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     dino.draw();
     drawScore();
-    drawGameOver(); // 강제로 다시 그리기
+    drawGameOver(); 
   } else if (gamePaused) {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
     dino.draw();
     drawScore();
-    drawPaused(); // 일시정지도 마찬가지로
-  } 
+    drawPaused(); 
+  }
 });


### PR DESCRIPTION
- 키보드 이벤트에 작동 제한 코드 추가
- (+ 추가: 모달 닫기 시, 게임 일시정지)

## PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 코드 품질을 위한 자체 리뷰를 진행했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] 변경사항이 다른 기능에 부작용을 일으키지 않는지 확인했습니다.

## 변경 내용 요약
1. 공룡게임 모달 비활성 상태일때에도, 게임의 스페이스바 이벤트가 작동하는 문제를 해결
- 키보드 이벤트에 해당 관련 작동 제한 코드 추가

2.(추가) 게임나가기(모달.close) 시에 게임이 일시정지 되도록 설정

## 영향을 받는 부분

<!-- 이 PR이 영향을 미치는 코드 영역이나 기능을 설명해주세요. -->

## 스크린샷 (선택사항)

다른 컴포넌트에서 스페이스바가 잘 적용되는지 확인

<1. 검색바>
<img width="615" height="114" alt="image" src="https://github.com/user-attachments/assets/a63679f8-500f-4d46-8188-bdd3da9353da" />

<2. 링크-모달>
<img width="1625" height="791" alt="image" src="https://github.com/user-attachments/assets/9eb2c8e4-d77c-4e3d-b3a2-8ddd63f9a258" />

<3. 투두리스트>
<img width="324" height="378" alt="image" src="https://github.com/user-attachments/assets/ac7945bb-fb84-4954-9912-97f51ccd036a" />

<4. 메모>
<img width="1632" height="710" alt="image" src="https://github.com/user-attachments/assets/881fa138-c827-4f12-83ff-538d35da3470" />


## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시: resolves #1 -->

resolves #
